### PR TITLE
[#7142] Add Webhook in front && Refactor AlarmService in backend

### DIFF
--- a/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-create-and-update.component.html
+++ b/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-create-and-update.component.html
@@ -45,6 +45,7 @@
                     <option value="all">All</option>
                     <option value="email">Email</option>
                     <option value="sms">SMS</option>
+                    <option *ngIf="systemConfiguration.webhookEnable" value="webhook">Webhook</option>
                     <option value="none">None</option>
                 </select>
                 <span class="fas fa-angle-down"></span>

--- a/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-create-and-update.component.ts
+++ b/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-create-and-update.component.ts
@@ -7,7 +7,8 @@ import { filterObj } from 'app/core/utils/util';
 export const enum NotificationType {
     ALL = 'all',
     EMAIL = 'email',
-    SMS = 'sms'
+    SMS = 'sms',
+    WEBHOOK = "webhook"
 }
 
 export interface IAlarmForm {
@@ -29,6 +30,7 @@ export class AlarmRuleCreateAndUpdateComponent implements OnInit, OnChanges {
     @Input() editAlarm: IAlarmRule;
     @Input() i18nLabel: {[key: string]: string};
     @Input() i18nFormGuide: {[key: string]: IFormFieldErrorType};
+    @Input() systemConfiguration: ISystemConfiguration
     @Output() outUpdateAlarm = new EventEmitter<IAlarmForm>();
     @Output() outCreateAlarm = new EventEmitter<IAlarmForm>();
     @Output() outClose = new EventEmitter<void>();
@@ -55,7 +57,16 @@ export class AlarmRuleCreateAndUpdateComponent implements OnInit, OnChanges {
         }
     }
 
-    private getTypeStr({smsSend, emailSend}: IAlarmRule): string {
+    private getTypeStr({smsSend, emailSend, webhookSend}: IAlarmRule): string {
+        if (this.systemConfiguration.webhookEnable) {
+            return smsSend && emailSend && webhookSend ? 'all'
+                : smsSend && emailSend ? 'sms, email'
+                : smsSend ? 'sms'
+                : emailSend ? 'email'
+                : webhookSend ? 'webhook'
+                : 'none';
+
+        }
         return smsSend && emailSend ? 'all'
             : smsSend ? 'sms'
             : emailSend ? 'email'

--- a/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-data.service.ts
+++ b/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-data.service.ts
@@ -11,6 +11,7 @@ export interface IAlarmRule {
     ruleId: string;
     serviceType: string;
     smsSend: boolean;
+    webhookSend: boolean;
     threshold: number;
     userGroupId: string;
 }

--- a/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-list-container.component.html
+++ b/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-list-container.component.html
@@ -29,6 +29,7 @@
                     <ng-template #list>
                         <pp-alarm-rule-list
                             [alarmRuleList]="alarmRuleList"
+                            [systemConfiguration]="systemConfiguration"
                             (outRemove)="onRemoveAlarm($event)"
                             (outEdit)="onEditAlarm($event)">
                         </pp-alarm-rule-list>
@@ -45,6 +46,7 @@
         [editAlarm]="editAlarm"
         [i18nLabel]="i18nLabel"
         [i18nFormGuide]="i18nFormGuide"
+        [systemConfiguration]="systemConfiguration"
         (outUpdateAlarm)="onUpdateAlarm($event)"
         (outCreateAlarm)="onCreateAlarm($event)"
         (outClose)="onClosePopup()"

--- a/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-list-container.component.ts
+++ b/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-list-container.component.ts
@@ -2,7 +2,13 @@ import { Component, OnInit, OnDestroy, ComponentFactoryResolver, Injector } from
 import { Subject, forkJoin } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 
-import { TranslateReplaceService, AnalyticsService, TRACKED_EVENT_LIST, DynamicPopupService } from 'app/shared/services';
+import {
+    TranslateReplaceService,
+    AnalyticsService,
+    TRACKED_EVENT_LIST,
+    DynamicPopupService,
+    SystemConfigurationDataService
+} from 'app/shared/services';
 import { UserGroupDataService, IUserGroup } from 'app/core/components/user-group/user-group-data.service';
 import { ApplicationListInteractionForConfigurationService } from 'app/core/components/application-list/application-list-interaction-for-configuration.service';
 import { NotificationType, IAlarmForm } from './alarm-rule-create-and-update.component';
@@ -27,6 +33,7 @@ export class AlarmRuleListContainerComponent implements OnInit, OnDestroy {
     checkerList: string[];
     userGroupList: string[];
     alarmRuleList: IAlarmRule[] = [];
+    systemConfiguration: ISystemConfiguration;
     i18nLabel = {
         CHECKER_LABEL: '',
         USER_GROUP_LABEL: '',
@@ -50,7 +57,8 @@ export class AlarmRuleListContainerComponent implements OnInit, OnDestroy {
         private analyticsService: AnalyticsService,
         private dynamicPopupService: DynamicPopupService,
         private componentFactoryResolver: ComponentFactoryResolver,
-        private injector: Injector
+        private injector: Injector,
+        private systemConfigurationDataService: SystemConfigurationDataService
     ) {}
 
     ngOnInit() {
@@ -58,11 +66,20 @@ export class AlarmRuleListContainerComponent implements OnInit, OnDestroy {
         this.loadUserGroupList();
         this.bindToAppSelectionEvent();
         this.initI18NText();
+        this.loadSystemConfiguration();
     }
 
     ngOnDestroy() {
         this.unsubscribe.next();
         this.unsubscribe.complete();
+    }
+
+    private loadSystemConfiguration(): void {
+        this.systemConfigurationDataService.getConfiguration().subscribe((result: ISystemConfiguration) => {
+            this.systemConfiguration = result;
+        }, (error: IServerErrorFormat) => {
+            this.errorMessage = error.exception.message;
+        });
     }
 
     private loadCheckerList(): void {
@@ -151,6 +168,7 @@ export class AlarmRuleListContainerComponent implements OnInit, OnDestroy {
             threshold,
             emailSend: type === NotificationType.ALL || type === NotificationType.EMAIL,
             smsSend: type === NotificationType.ALL || type === NotificationType.SMS,
+            webhookSend: (this.systemConfiguration.webhookEnable && type === NotificationType.ALL) || type === NotificationType.WEBHOOK,
             notes
         }).subscribe((response: IAlarmRuleCreated | IServerErrorShortFormat) => {
             if (isThatType<IServerErrorShortFormat>(response, 'errorCode', 'errorMessage')) {
@@ -179,6 +197,7 @@ export class AlarmRuleListContainerComponent implements OnInit, OnDestroy {
             threshold,
             emailSend: type === NotificationType.ALL || type === NotificationType.EMAIL,
             smsSend: type === NotificationType.ALL || type === NotificationType.SMS,
+            webhookSend: (this.systemConfiguration.webhookEnable && type === NotificationType.ALL) || type === NotificationType.WEBHOOK,
             notes
         }).subscribe((response: IAlarmRuleResponse | IServerErrorShortFormat) => {
             if (isThatType<IServerErrorShortFormat>(response, 'errorCode', 'errorMessage')) {

--- a/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-list.component.html
+++ b/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-list.component.html
@@ -2,7 +2,7 @@
     <div>{{alarm.checkerName}}</div>
     <div>{{alarm.userGroupId}}</div>
     <div>{{alarm.threshold}}</div>
-    <div>{{getNotificationType(alarm.emailSend, alarm.smsSend)}}</div>
+    <div>{{getNotificationType(alarm.emailSend, alarm.smsSend, alarm.webhookSend)}}</div>
     <div class="l-alarm-rules-btn-group">
         <button [hidden]="isRemoveTarget(alarm.ruleId)" class="far fa-edit" (click)="onEdit(alarm.ruleId)"></button>
         <button [hidden]="isRemoveTarget(alarm.ruleId)" class="far fa-trash-alt" (click)="onRemove(alarm.ruleId)"></button>

--- a/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-list.component.ts
+++ b/web/src/main/angular/src/app/core/components/alarm-rule-list/alarm-rule-list.component.ts
@@ -9,6 +9,7 @@ import { IAlarmRule } from './alarm-rule-data.service';
 })
 export class AlarmRuleListComponent implements OnInit {
     @Input() alarmRuleList: IAlarmRule[];
+    @Input() systemConfiguration: ISystemConfiguration
     @Output() outRemove = new EventEmitter<string>();
     @Output() outEdit = new EventEmitter<string>();
 
@@ -16,7 +17,17 @@ export class AlarmRuleListComponent implements OnInit {
 
     constructor() {}
     ngOnInit() {}
-    getNotificationType(emailSend: boolean, smsSend: boolean): string {
+    getNotificationType(emailSend: boolean, smsSend: boolean, webhookSend: boolean): string {
+        if (this.systemConfiguration.webhookEnable) {
+            return !emailSend && !smsSend && !webhookSend ? 'None'
+                : !emailSend && !smsSend && webhookSend ? 'Webhook'
+                : !emailSend && smsSend && !webhookSend ? 'SMS'
+                : emailSend && !smsSend && !webhookSend ? 'Email'
+                : emailSend && smsSend && !webhookSend ? 'Email, SMS'
+                : emailSend && !smsSend && webhookSend ? 'Email, Webhook'
+                : !emailSend && smsSend && webhookSend ? 'SMS, Webhook'
+                : 'Email, SMS, Webhook';
+        }
         return !emailSend && !smsSend ? 'None'
             : emailSend && !smsSend ? 'Email'
             : !emailSend && smsSend ? 'SMS'

--- a/web/src/main/angular/src/app/shared/services/system-configuration-data.service.ts
+++ b/web/src/main/angular/src/app/shared/services/system-configuration-data.service.ts
@@ -14,6 +14,7 @@ export class SystemConfigurationDataService {
         showActiveThread: false,
         showActiveThreadDump: false,
         showApplicationStat: false,
+        webhookEnable: false,
         version: '',
         userId: '',
         userName: '',

--- a/web/src/main/angular/src/globals.d.ts
+++ b/web/src/main/angular/src/globals.d.ts
@@ -373,6 +373,7 @@ interface ISystemConfiguration {
     showActiveThread: boolean;
     showActiveThreadDump: boolean;
     showApplicationStat: boolean;
+    webhookEnable: boolean;
     version: string;
     userId?: string;
     userName?: string;

--- a/web/src/main/java/com/navercorp/pinpoint/web/alarm/SpringWebhookSender.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/alarm/SpringWebhookSender.java
@@ -49,7 +49,7 @@ public class SpringWebhookSender implements WebhookSender {
         
         this.batchConfiguration = batchConfiguration;
         this.webhookReceiverUrl = batchConfiguration.getWebhookReceiverUrl();
-        this.webhookEnable = batchConfiguration.getWebhookEnable();
+        this.webhookEnable = batchConfiguration.isWebhookEnable();
         this.springRestTemplate = springRestTemplate;
     }
     

--- a/web/src/main/java/com/navercorp/pinpoint/web/batch/BatchConfiguration.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/batch/BatchConfiguration.java
@@ -142,7 +142,7 @@ public class BatchConfiguration {
 
     public String getWebhookReceiverUrl() { return webhookReceiverUrl; }
 
-    public boolean getWebhookEnable() {
+    public boolean isWebhookEnable() {
         return webhookEnable;
     }
 

--- a/web/src/main/java/com/navercorp/pinpoint/web/service/AlarmServiceImpl.java
+++ b/web/src/main/java/com/navercorp/pinpoint/web/service/AlarmServiceImpl.java
@@ -20,6 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import com.navercorp.pinpoint.web.batch.BatchConfiguration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import com.navercorp.pinpoint.web.alarm.checker.AlarmChecker;
@@ -37,14 +39,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlarmServiceImpl implements AlarmService {
 
     private final AlarmDao alarmDao;
-
-    public AlarmServiceImpl(AlarmDao alarmDao) {
+    private final boolean webhookEnable;
+    
+    public AlarmServiceImpl(AlarmDao alarmDao, BatchConfiguration batchConfiguration) {
+        Objects.requireNonNull(batchConfiguration, "batchConfiguration");;
         this.alarmDao = Objects.requireNonNull(alarmDao, "alarmDao");
+        this.webhookEnable = batchConfiguration.isWebhookEnable();
     }
-
+    
     @Override
     public String insertRule(Rule rule) {
-        if (rule.isWebhookSend()) {
+        if (webhookEnable) {
             return alarmDao.insertRule(rule);
         }
         return alarmDao.insertRuleExceptWebhookSend(rule);
@@ -70,7 +75,7 @@ public class AlarmServiceImpl implements AlarmService {
 
     @Override
     public void updateRule(Rule rule) {
-        if (rule.isWebhookSend()) {
+        if (webhookEnable) {
             alarmDao.updateRule(rule);
         } else {
             alarmDao.updateRuleExceptWebhookSend(rule);

--- a/web/src/test/java/com/navercorp/pinpoint/web/alarm/AlarmReaderTest.java
+++ b/web/src/test/java/com/navercorp/pinpoint/web/alarm/AlarmReaderTest.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.navercorp.pinpoint.web.batch.BatchConfiguration;
 import com.navercorp.pinpoint.web.dao.AlarmDao;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -71,7 +72,7 @@ public class AlarmReaderTest {
         ExecutionContext executionContext = new ExecutionContext();
         stepExecution.setExecutionContext(executionContext);
         
-        AlarmServiceImpl alarmService = new AlarmServiceImpl(mock(AlarmDao.class)) {
+        AlarmServiceImpl alarmService = new AlarmServiceImpl(mock(AlarmDao.class), mock(BatchConfiguration.class)) {
             @Override
             public java.util.List<Rule> selectRuleByApplicationId(String applicationId) {
                 return new LinkedList<>();
@@ -114,7 +115,7 @@ public class AlarmReaderTest {
             
         };
 
-        alarmService = new AlarmServiceImpl(mock(AlarmDao.class)) {
+        alarmService = new AlarmServiceImpl(mock(AlarmDao.class), mock(BatchConfiguration.class)) {
             private final Map<String, Rule> ruleMap ;
 
             {


### PR DESCRIPTION
1. **이전 버젼(webhook기능 지원 이전)의 pinpoint 사용자**

   - 기존 SMS, Email 전송 타입만 제공할 때 부터 pinpoint-web을 사용한 User를 가르킨다.
   - webhook의 기능을 사용하고 싶다면
     백과 프론트를 webhook 기능이 존재하는 버젼으로 업데이트하고, webhook.enable = true로 설정, webhook.receiver.url 입력, DB alarm_rule 테이블에 webhook_send 컬럼 추가
     - 이전 버젼의 DB 사용자(alarm_rule 테이블에 webhook_send 컬럼 존재 x)를 위해 하위 호환 쿼리를 만들었다.
       webhook.enable로써 테이블의 스키마 변경을 구분하며, 이를 통해 DB Service 단에서 적절한 쿼리 호출을 위한 분기를 진행한다.
   - 여러 설정을 마치고 webhook의 기능을 사용한 사용자가 사용도중 webhook.enable=false로 설정하게 되면 front단에서는 어떻게 보여 줄 것인가?
     - webhook.enable로서 front의 alarm_list, alarm_create_update_form에 webhook을 적용할지 안할지 구분했다.
     - webhook.enable=false 시, front의 alarm_list와 alarm_create_update_form에서는 webhook을 볼 수 없다.
       (DB에 저장된 해당 Rule의 webhook_send 값이 true이더라도, webhook.enable=false로 설정한 사용자는 해당 데이터의 webhook_send의 값을 프론트에서 변경할 수 도 볼 수 도 없다.)  => SMS, Email 전송 타입만 프론트에서 보여지고 수정할 수 있다.
     - webhook.enable=true 시, front단에서 alarm_list와 alarm_create_update_form에서는 webhook_send 컬럼의 값을 볼 수 있게 되고, 수정할 수 있게 된다.
   - webhook.enable=false로 설정하게 되면 batch작업시 webhook Sender 또한 동작을 멈출 것이다.

2. **처음부터 webhook_send 기능이 있는 pinpoint 버젼 사용자.**

   - 프론트, 백, DB모두 webhook 기능을 사용하기에 적절한 버젼을 사용하는 유저를 가리킨다.
   - 위의 유저가 webhook.enable=false로 설정할 경우
     - webhook.enable로서 front의 alarm_list, alarm_create_update_form에 webhook을 적용할지 안할지 구분했다.
     - webhook.enable=false 시, front의 alarm_list와 alarm_create_update_form에서는 webhook을 볼 수 없다.
       (DB에 저장된 해당 Rule의 webhook_send 값이 true이더라도, webhook.enable=false로 설정한 사용자는 해당 데이터의 webhook_send의 값을 프론트에서 변경할 수 도 볼 수 도 없다.)  => SMS, Email 전송 타입만 프론트에서 보여지고 수정할 수 있다.
     - webhook.enable=true 시, front단에서 alarm_list와 alarm_create_update_form에서는 webhook_send 컬럼의 값을 볼 수 있게 되고, 수정할 수 있게 된다.
   - webhook.enable=false로 설정하게 되면 batch작업시 Sender또한 동작을 멈출 것이다.



#### **아래의 그림은 webhook.enable = false / true에 따른 프론트에서 동일한 데이터를 어떠한 방식으로 보여주는지에 대한 그림이다.**

**webhook.enable = false**

- alarm_rule 테이블에 webhook_send의 값에 관계없이 webhook은 alarm_list에 보이지 않는다.
  webhook Type의 Alarm도 생성할 수 없을 뿐더러 특정 alarm의 Type 변경시 webhook이 포함된 타입으로 변경할 수 없다.

<img width="1680" alt="Screen Shot 2020-09-05 at 12 18 14 PM" src="https://user-images.githubusercontent.com/47495187/92297376-a82faf00-ef79-11ea-8727-70cf11a6aaec.png">

**webhook.enable = true** 

- alarm_rule 테이블에 webhook_send의 값이 true일경우, alarm list에 해당 값이 보일 뿐더러, Type이 webhook인 alarm을 생성 및 수정 가능하다.

<img width="1680" alt="Screen Shot 2020-09-05 at 12 19 20 PM" src="https://user-images.githubusercontent.com/47495187/92297381-b087ea00-ef79-11ea-9990-2d12ccde4f7e.png">